### PR TITLE
Update to work with sysctl

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,20 +1,14 @@
----     
+---
 driver_plugin: vagrant
 platforms:
-- name: centos-6.3
+- name: centos-6.7
   driver_config:
-    box: opscode-centos-6.3
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/boxes/opscode-centos-6.3.box
     customize:
         memory: 3072
-    run_list: []
-- name: centos-5.8
+- name: centos-5.11
   driver_config:
-    box: opscode-centos-5.8
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/boxes/opscode-centos-5.8.box
     customize:
         memory: 3072
-    run_list: []
 suites:
 - name: default
   run_list:

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,6 @@
-chef_api :config
-site :opscode
+source 'https://supermarket.chef.io'
 
+# Read the cookbook dependencies from the metadata.rb file
 metadata
+
 cookbook 'minitest-handler'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: oracle 
+# Cookbook Name:: oracle
 # Recipe:: default
 #
 # Copyright 2010, Eric G. Wolfe
@@ -57,10 +57,10 @@ default["oracle"]["db_packages"] = [
 # User-tunable attributes, and Oracle recommended
 # MINIMUM values for all versions of Oracle
 default["oracle"]["processes"] = 240
-override["kernel"]["shmall"] = 2097152
-override["kernel"]["shmmni"] = 4096
-override["net"]["core"]["rmem_default"] = 262144
-override["net"]["core"]["wmem_default"] = 262144
+override['sysctl']['params']["kernel"]["shmall"] = 2097152
+override['sysctl']['params']["kernel"]["shmmni"] = 4096
+override['sysctl']['params']["net"]["core"]["rmem_default"] = 262144
+override['sysctl']['params']["net"]["core"]["wmem_default"] = 262144
 
 # User-tunable attribues, and Oracle recommended
 # MINIMUM values for 11g version of Oracle
@@ -72,31 +72,31 @@ default["security"]["limits"] = [
     "oracle    soft    memlock 3145728",
     "oracle    hard    memlock 3145728"
 ]
-default["fs"]["file_max"] = 6815744
-default["fs"]["aio_max_nr"] = 1048576
-default["net"]["ipv4"]["ip_local_port_range"] = "9000 65500"
-default["net"]["core"]["rmem_max"] = 4194304
-default["net"]["core"]["wmem_max"] = 1048576
+default['sysctl']['params']["fs"]["file_max"] = 6815744
+default['sysctl']['params']["fs"]["aio_max_nr"] = 1048576
+default['sysctl']['params']["net"]["ipv4"]["ip_local_port_range"] = "9000 65500"
+default['sysctl']['params']["net"]["core"]["rmem_max"] = 4194304
+default['sysctl']['params']["net"]["core"]["wmem_max"] = 1048576
 
 # Values below are calculated
 # Four Gb of RAM expressed in Kb
 memory_fourgb = 4194304
 
 # Calculated semaphore settings in accordance with Oracle documentation
-override["kernel"]["semmsl"] = node["oracle"]["processes"] + 10 
-override["kernel"]["semmni"] = 128
-override["kernel"]["semmns"] = node["kernel"]["semmsl"] * node["kernel"]["semmni"]
-override["kernel"]["semopm"] = node["kernel"]["semmsl"]
+override['sysctl']['params']["kernel"]["semmsl"] = node["oracle"]["processes"] + 10
+override['sysctl']['params']["kernel"]["semmni"] = 128
+override['sysctl']['params']["kernel"]["semmns"] = node['sysctl']['params']["kernel"]["semmsl"] * node['sysctl']['params']["kernel"]["semmni"]
+override['sysctl']['params']["kernel"]["semopm"] = node['sysctl']['params']["kernel"]["semmsl"]
 
 # Calculated shmmax by architecture and amount of RAM
 if node["kernel"]["machine"] =~ /^(x|i[3456])86$/i
   # Set shmmax to lower of 2350000000, or half of memory.
   if ( node["memory"]["total"].to_i > memory_fourgb )
-    override["kernel"]["shmmax"] = 3000000000
+    override['sysctl']['params']["kernel"]["shmmax"] = 3000000000
   else
-    override["kernel"]["shmmax"] = ( ( node["memory"]["total"].to_i * 1024 ) / 2 )
+    override['sysctl']['params']["kernel"]["shmmax"] = ( ( node["memory"]["total"].to_i * 1024 ) / 2 )
   end
 elsif node["kernel"]["machine"] =~ /^(x86_|amd)64$/i
   # Set shmmax to half of memory.
-  override["kernel"]["shmmax"] = ( ( node["memory"]["total"].to_i * 1024 ) / 2 )
+  override['sysctl']['params']["kernel"]["shmmax"] = ( ( node["memory"]["total"].to_i * 1024 ) / 2 )
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,11 +4,11 @@ maintainer_email "wolfe21@marshall.edu"
 license          "Apache 2.0"
 description      "Installs/Configures oracle pre-requisites."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
-depends          "el-sysctl"
+version          "1.0"
+
+depends          "sysctl"
 depends          "x-windows"
 depends          "gnome"
-conflicts        "sysctl"
 
 %w{ redhat centos scientific }.each do |os|
   supports os, ">= 5.0"

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -44,4 +44,5 @@ directory "/u01/app/oracle" do
   recursive true
 end
 
-include_recipe "el-sysctl"
+include_recipe "sysctl::default"
+include_recipe "sysctl::apply"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,15 +50,14 @@ end
 
 user "oracle" do
   comment "Oracle Service Account - DBA"
-  uid 200
   home "/home/oracle"
   shell "/bin/bash"
+  system true
   ignore_failure true
   supports :manage_home => true
 end
 
 group "dba" do
-  gid 200
   ignore_failure true
   members node["oracle"]["dbas"]
 end
@@ -70,4 +69,5 @@ directory "/u01/app/oracle" do
   recursive true
 end
 
-include_recipe "el-sysctl"
+include_recipe "sysctl::default"
+include_recipe "sysctl::apply"


### PR DESCRIPTION
Since this is a breaking change on any overrides, this bumps the version to 1.0.0.

Mostly this was just changing attribute names. I didn't spend a ton of time,
but the tests pass :)

Also changed the user/group create to not specify bare ID numbers. I couldn't
see anywhere that indicated this was a requirement, so it's now just a system
account. This was done to prevent an error on CentOS 5.x where the user create
with ID 200 also created a group with ID 200 and then failed on the group
create.
